### PR TITLE
Trying to fix network idle error on UI tests

### DIFF
--- a/test/Chirp.Web.Playwright.Test/UiTests.cs
+++ b/test/Chirp.Web.Playwright.Test/UiTests.cs
@@ -472,7 +472,7 @@ public class UiTests : PageTest, IClassFixture<CustomTestWebApplicationFactory>,
         await _page.Locator("input[id='Input_Password']").PressAsync("Tab"); 
         await _page.Locator("input[id='Input_ConfirmPassword']").FillAsync("Cecilie1234!");
         await _page.GetByRole(AriaRole.Button, new() { NameString = "Register" }).ClickAsync();
-        await _page.WaitForURLAsync(_serverAddress);
+        await _page.GetByText("What's on your mind Cecilie?").WaitForAsync();
     }
 
     private async Task InitializeBrowserAndCreateBrowserContextAsync() 


### PR DESCRIPTION
Waiting for an element on the page at serveraddress instead of solely relying on the URL. It is weird because it only occured on one test even tough its in the setup method it fails, that a lot of the other tests are also using. 